### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish Latest to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: fabiansdp/golang_rest_api/golang_backend
           username: ${{ secrets.PKG_REGISTRY_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore